### PR TITLE
Bugfix: Do not interpret the argument to -i as an integer.

### DIFF
--- a/ogimet_downloader.py
+++ b/ogimet_downloader.py
@@ -4,7 +4,7 @@ parser = argparse.ArgumentParser()
 
 parser.add_argument("-s", "--start", dest = "start", help="From what date script should start. example: 01/2016")
 parser.add_argument("-e", "--end", dest = "end", help="To what date script should work. example: 05/2016")
-parser.add_argument("-i", "--ind",dest ="station", default=12560, help="Station ind number. Default is Katowice(12560)",type=int)
+parser.add_argument("-i", "--ind",dest ="station", default=12560, help="Station ind number. Default is Katowice(12560)")
 parser.add_argument("-f", "--file",dest = "file", help="To what file script should write")
 
 args = parser.parse_args()


### PR DESCRIPTION
Hi everyone, I love your script, it is super useful! When looking at Swiss stations, though, I noticed that many of them (e.g. 06604) don't work, as it gets converted to 6604. Maybe just not interpreting the input as an integer is enough to fix this?

Best
Stephan